### PR TITLE
Dropping minor versions from autotests

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -47,26 +47,12 @@ jobs:
     - name: Test against Gluetun v3.38
       run: make GLUETUN_VERSION=v3.38 pr-test
 
-  pr-check-against-3-38-1:
-    runs-on: ubuntu-24.04
-    steps:
-    - uses: actions/checkout@v3
-    - name: Test against Gluetun v3.38.1
-      run: make GLUETUN_VERSION=v3.38.1 pr-test
-
   pr-check-against-3-39:
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v3
     - name: Test against Gluetun v3.39
       run: make GLUETUN_VERSION=v3.39 pr-test
-
-  pr-check-against-3-39-1:
-    runs-on: ubuntu-24.04
-    steps:
-    - uses: actions/checkout@v3
-    - name: Test against Gluetun v3.39.1
-      run: make GLUETUN_VERSION=v3.39.1 pr-test
 
   pr-check-against-3-40-0:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
Number of concurrent tests we can run together is limited given shared VPN account. Running all tests linearly turned out to be pretty difficult and time consuming to debug, so unless funding for dedicated VPN account is sorted here, I'll keep these off.  

Latest (wether major, minor, patch/bugfix) will run, always.