### PR TITLE
Move from Open VPN to generic API endpoints

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -103,7 +103,7 @@ get_transmission_port() {
 
 # get peer port from vpn via gluetun control server
 get_gluetun_port() {
-    gluetun_response=$(curl -s -H "X-API-Key: $GLUETUN_CONTROL_API_KEY" "$GLUETUN_CONTROL_ENDPOINT/v1/openvpn/portforwarded")
+    gluetun_response=$(curl -s -H "X-API-Key: $GLUETUN_CONTROL_API_KEY" "$GLUETUN_CONTROL_ENDPOINT/v1/portforward")
     if [ "$gluetun_response" == "" ] || [ "$gluetun_response" == '{"port":0}' ]; then
         log "gluetun returned $gluetun_response, retrying ($gluetun_port_fail_count / $GLUETUN_PICK_NEW_SERVER_AFTER)..."
         return 1
@@ -126,7 +126,7 @@ check_transmission_port_open() {
 # pick a new gluetun server
 pick_new_gluetun_server() {
     log "asking gluetun to disconnect from $country_details", "s#$country_details#* OMITTED *#"
-    gluetun_server_response=$(curl -s -H "X-API-Key: $GLUETUN_CONTROL_API_KEY" -X PUT -d '{"status":"stopped"}' "$GLUETUN_CONTROL_ENDPOINT/v1/openvpn/status") || log "error instructing gluetun to pick new server ($gluetun_server_response)."
+    gluetun_server_response=$(curl -s -H "X-API-Key: $GLUETUN_CONTROL_API_KEY" -X PUT -d '{"status":"stopped"}' "$GLUETUN_CONTROL_ENDPOINT/v1/vpn/status") || log "error instructing gluetun to pick new server ($gluetun_server_response)."
     if ! echo "$gluetun_server_response" | grep -qE '\{"outcome":"(stopping|stopped)"\}'; then
         log "bleh, gluetun server response is weird, expected one of {\"outcome\":\"stopping\"} or {\"outcome\":\"stopped\"}, got $gluetun_server_response"
         return 1


### PR DESCRIPTION
Moving `/v1/openvpn/portforwarded` to `/v1/portforward` and `/v1/openvpn/status` to `/v1/vpn/status` to enable wireguard configs also - the smarter bits might not work, and error handling is likely not going to be quite right, but I think this should be enough to make it functional