### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -15,6 +15,9 @@ on:
   schedule:
       - cron: "0 6 * * *"
 
+permissions:
+  contents: read
+
 env:
   GLUETRANS_VPN_USERNAME: ${{ secrets.GLUETRANS_VPN_USERNAME }}
   GLUETRANS_VPN_PASSWORD: ${{ secrets.GLUETRANS_VPN_PASSWORD }}


### PR DESCRIPTION
Potential fix for [https://github.com/miklosbagi/gluetrans/security/code-scanning/10](https://github.com/miklosbagi/gluetrans/security/code-scanning/10)

In general, the fix is to explicitly declare a `permissions` block for the workflow or for each job, limiting the `GITHUB_TOKEN` to the least privileges required. Since all jobs here only need to read the repository contents (for `actions/checkout`), setting `contents: read` at the top level is sufficient and conservative. Additional scopes (like `packages: read`) can be added later if needed.

The single best fix, without changing behavior, is to add a workflow-level `permissions` block immediately after the `on:` triggers block. This will apply to all jobs (`lint-docker`, `lint-sh`, and the various `pr-check-*` jobs) and avoid repeating configuration for each job. For now, we declare `contents: read`, which is enough for `actions/checkout@v3` and for the steps that run `make`. No other code, imports, or external libraries are needed; this is a pure YAML configuration change within `.github/workflows/pr-check.yml`.

Concretely:
- Edit `.github/workflows/pr-check.yml`.
- Insert:

  ```yaml
  permissions:
    contents: read
  ```

  between the `on:` block (line 2–16) and the `env:` block (line 18+).  
This will restrict the `GITHUB_TOKEN` for all jobs in this workflow to read-only access to repository contents, satisfying the CodeQL rule and improving security while preserving existing functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
