### PR TITLE
fix: Add job-level permissions for OSV scanner reusable workflows

### DIFF
--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -26,10 +26,16 @@ permissions:
   security-events: write
   # Read commit contents
   contents: read
+  # Required for reusable workflows
+  actions: read
 
 jobs:
   scan-scheduled:
     if: ${{ github.event_name == 'push' || github.event_name == 'schedule' }}
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
     uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@v1.9.0"
     with:
       # Example of specifying custom arguments
@@ -39,6 +45,10 @@ jobs:
         ./
   scan-pr:
     if: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
     uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@v1.9.0"
     with:
       # Example of specifying custom arguments


### PR DESCRIPTION
## Summary

Fixes the OSV-Scanner workflow validation error by properly configuring permissions for reusable workflows.

## Problem

The workflow failed with:
```
Invalid workflow file: .github/workflows/osv-scanner.yml#L31
The workflow is requesting 'actions: read', but is only allowed 'actions: none'.
```

**Root cause**: When calling reusable workflows with `uses:`, GitHub Actions does **not** automatically inherit workflow-level permissions. Each job must explicitly declare its permissions.

## Solution

Added `permissions:` blocks to both jobs that call reusable workflows:

```yaml
jobs:
  scan-scheduled:
    permissions:
      security-events: write
      contents: read
      actions: read  # ← Required by reusable workflow
    uses: "google/osv-scanner-action/..."

  scan-pr:
    permissions:
      security-events: write
      contents: read
      actions: read  # ← Required by reusable workflow
    uses: "google/osv-scanner-action/..."
```

## Why This Works

GitHub Actions permissions inheritance:
- ✅ Regular jobs inherit workflow-level permissions
- ❌ Reusable workflows do NOT inherit workflow-level permissions
- ✅ Reusable workflows require explicit job-level permissions

## Testing

- Workflow file syntax is now valid
- Permissions properly configured for both jobs
- OSV-Scanner should run successfully on next trigger

## References

- [GitHub Actions: Reusable workflows](https://docs.github.com/en/actions/using-workflows/reusing-workflows#passing-inputs-and-secrets-to-a-reusable-workflow)
- [OSV-Scanner Action](https://github.com/google/osv-scanner-action)